### PR TITLE
Add top locations stats to footer

### DIFF
--- a/src/FilmStruck.Cli/FilmStruck.Cli.csproj
+++ b/src/FilmStruck.Cli/FilmStruck.Cli.csproj
@@ -13,7 +13,7 @@
 
     <!-- NuGet package metadata -->
     <PackageId>FilmStruck.Cli</PackageId>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Authors>Shreshth Khilani</Authors>
     <Description>A CLI tool for tracking your film watching history with TMDB integration. Generate a beautiful static site to showcase your film log.</Description>
     <PackageProjectUrl>https://github.com/shreshthkhilani/filmstruck</PackageProjectUrl>

--- a/src/FilmStruck.Cli/Templates/app.js
+++ b/src/FilmStruck.Cli/Templates/app.js
@@ -50,6 +50,7 @@ function calculateStats(films) {
     lastWatched: films.length > 0 ? sortFilms(films)[0].date : '',
     directors: {},
     languages: {},
+    locations: {},
     decades: {},
     companions: {}
   };
@@ -72,6 +73,11 @@ function calculateStats(films) {
     // Languages
     if (f.language) {
       stats.languages[f.language] = (stats.languages[f.language] || 0) + 1;
+    }
+
+    // Locations
+    if (f.location) {
+      stats.locations[f.location] = (stats.locations[f.location] || 0) + 1;
     }
 
     // Release decades
@@ -187,6 +193,15 @@ function renderStats(stats, filter) {
     html += '<div class="stat-col">';
     html += '<div class="stat-header">top decades</div>';
     html += topDecades.map(([name, count]) => '<div>' + name + ': ' + count + '</div>').join('');
+    html += '</div>';
+  }
+
+  // Top locations
+  const topLocations = getTopN(stats.locations, 3);
+  if (topLocations.length > 0) {
+    html += '<div class="stat-col">';
+    html += '<div class="stat-header">top locations</div>';
+    html += topLocations.map(([name, count]) => '<div>' + escapeHtml(name) + ': ' + count + '</div>').join('');
     html += '</div>';
   }
 


### PR DESCRIPTION
## Summary

- Add a "top locations" stat column to the footer stats display
- Shows the top 3 most frequent viewing locations with their counts
- Follows the same pattern as existing stats (directors, languages, decades, companions)

## Test plan

- [x] Run `dotnet build && dotnet pack` from `src/FilmStruck.Cli`
- [x] Install the new version of the CLI globally
- [x] Navigate to a test repo with some data and run `filmstruck build`
- [x] Open the generated `index.html` in a browser
- [x] Verify "top locations" column appears in the footer stats
- [x] Verify it shows the correct top 3 locations with counts

## Migration for existing users

Users with existing FilmStruck repositories just need to:
1. Update the tool and rebuild locally: `dotnet tool update -g FilmStruck.Cli && filmstruck build`
2. Push a new commit or kick off a new build remotely, like on GH Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)