### PR TITLE
Add CLI flags to filmstruck add command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,30 @@ Interactive prompts guide you through:
 5. Location
 6. Companions (optional)
 
+**Options:**
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--title` | `-t` | Film title for TMDB search |
+| `--date` | `-d` | Watch date in M/d/yyyy format (default: today) |
+| `--location` | `-l` | Where the film was watched |
+| `--companions` | `-c` | Comma-separated list of companions |
+| `--default-poster` | | Use the default/first poster without prompting |
+| `--tmdb-id` | | TMDB movie ID (skips search and confirmation) |
+
+Any flags provided will skip the corresponding interactive prompt. This allows for scripted or partially automated usage:
+
+```bash
+# Fully automated (no prompts)
+filmstruck add --tmdb-id 27053 -d 1/29/2026 -l Home -c "Alice,Bob" --default-poster
+
+# Search by title, skip other prompts
+filmstruck add -t "The Matrix" -d 1/15/2026 -l "AMC Theater" -c ""
+
+# Just use default poster, prompt for everything else
+filmstruck add --default-poster
+```
+
 ### `filmstruck enrich`
 
 Look up TMDB IDs for existing log entries that don't have one.


### PR DESCRIPTION
## Summary
- Add command-line flags (`--title`, `--date`, `--location`, `--companions`, `--default-poster`, `--tmdb-id`) to `filmstruck add` to skip interactive prompts
- Users can provide any subset of flags; missing values still prompt interactively
- Includes input validation for date format (M/d/yyyy) and TMDB ID (positive integer)
- Add documentation to README.md with usage examples

## Test plan
- [x] Run `filmstruck add --help` to verify all flags appear with descriptions
- [x] Test invalid date format: `filmstruck add --date "invalid"` should fail validation
- [x] Test invalid TMDB ID: `filmstruck add --tmdb-id -5` should fail validation
- [x] Test with all flags (should have no prompts): `filmstruck add --tmdb-id 27053 -d 1/29/2026 -l Home -c "Test" --default-poster`
- [x] Test with partial flags (should prompt for missing values)
- [x] Test non-existent TMDB ID shows appropriate error

🤖 Generated with [Claude Code](https://claude.com/claude-code)