### PR TITLE
Prepare release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to FilmStruck CLI will be documented in this file.
+
+## [1.2.0] - 2026-02-01
+
+### Added
+- **Link-based poster selection**: Poster selection now displays clickable URLs for each poster option. Cmd+click (or Ctrl+click) to preview posters directly in your browser, then enter a number to select. Shows top 5 posters with resolution and language info.
+
+### Fixed
+- **Placeholder poster images**: Films without poster artwork now display a placeholder image instead of a broken image icon.
+- **Same-day log ordering**: When multiple films are logged for the same date, the original entry order is now preserved in the generated site.
+
+## [1.1.0] - 2025-01-29
+
+### Added
+- CLI flags for `filmstruck add` command (`--title`, `--date`, `--location`, `--companions`, `--default-poster`, `--tmdb-id`)
+- `import-letterboxd-diary` command for importing Letterboxd diary exports
+
+## [1.0.0] - 2025-01-15
+
+### Added
+- Initial release
+- `init` command to create a new filmstruck repository
+- `add` command with TMDB integration and poster selection
+- `enrich` command to look up TMDB IDs for existing entries
+- `build` command to generate static site
+- `calculate` command for statistics
+- GitHub Pages deployment workflow

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ filmstruck add
 Interactive prompts guide you through:
 1. Film title (searches TMDB)
 2. Select from search results
-3. Choose poster
+3. Choose poster (displays clickable URLs - Cmd+click to preview)
 4. Date watched
 5. Location
 6. Companions (optional)
@@ -231,6 +231,8 @@ See a fully populated example at [s4s-filmstruck](https://github.com/shreshthkhi
 See [CONTRIBUTING.md](CONTRIBUTING.md) for information on developing the CLI.
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for technical specification.
+
+See [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## License
 

--- a/src/FilmStruck.Cli/FilmStruck.Cli.csproj
+++ b/src/FilmStruck.Cli/FilmStruck.Cli.csproj
@@ -13,7 +13,7 @@
 
     <!-- NuGet package metadata -->
     <PackageId>FilmStruck.Cli</PackageId>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>Shreshth Khilani</Authors>
     <Description>A CLI tool for tracking your film watching history with TMDB integration. Generate a beautiful static site to showcase your film log.</Description>
     <PackageProjectUrl>https://github.com/shreshthkhilani/filmstruck</PackageProjectUrl>


### PR DESCRIPTION
## Summary
- Bump version from 1.1.0 to 1.2.0
- Add CHANGELOG.md documenting all releases
- Update README with new poster selection description and changelog link

## Release 1.2.0 Highlights

### Added
- **Link-based poster selection**: Poster selection now displays clickable URLs for each poster option

### Fixed
- **Placeholder poster images**: Films without poster artwork now display a placeholder image
- **Same-day log ordering**: Original entry order preserved when multiple films logged for the same date

## Test plan
- [x] Verify version is 1.2.0 in .csproj
- [x] Verify CHANGELOG.md is accurate
- [ ] After merge, create GitHub release with tag `v1.2.0` to trigger NuGet publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)