### PR TITLE
Add filmstruck hearts commands (add/remove)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,34 @@ The command will:
 - Prompt for location (with recent location suggestions) and companions
 - Save to `log.csv` and `films.csv`, then recalculate stats
 
+### `filmstruck hearts`
+
+Manage your favorite films. Favorites are stored in `data/hearts.csv` and displayed in a dedicated section on your site.
+
+#### `filmstruck hearts add`
+
+Add a film to your favorites.
+
+```bash
+# Interactive: select from your logged films
+filmstruck hearts add
+
+# Direct: add by TMDB ID
+filmstruck hearts add --tmdb-id 550
+```
+
+#### `filmstruck hearts remove`
+
+Remove a film from your favorites.
+
+```bash
+# Interactive: select from your favorites
+filmstruck hearts remove
+
+# Direct: remove by TMDB ID
+filmstruck hearts remove --tmdb-id 550
+```
+
 ## Configuration
 
 Configuration is stored in `filmstruck.json`:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -165,4 +165,15 @@ else
     fail "build: index.html not generated"
 fi
 
+# Test 5: hearts commands (add and remove favorites)
+rm -f data/hearts.csv
+run_command hearts add --tmdb-id 238 >/dev/null 2>&1 || true
+run_command hearts add --tmdb-id 680 >/dev/null 2>&1 || true
+run_command hearts remove --tmdb-id 238 >/dev/null 2>&1 || true
+if [ -f "data/hearts.csv" ] && grep -q "680" data/hearts.csv && ! grep -q "238" data/hearts.csv; then
+    pass "hearts"
+else
+    fail "hearts: expected 680 in hearts.csv and 238 removed"
+fi
+
 print_summary

--- a/src/FilmStruck.Cli/Commands/Hearts/HeartsAddCommand.cs
+++ b/src/FilmStruck.Cli/Commands/Hearts/HeartsAddCommand.cs
@@ -1,0 +1,106 @@
+using System.ComponentModel;
+using FilmStruck.Cli.Services;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace FilmStruck.Cli.Commands.Hearts;
+
+public class HeartsAddCommand : AsyncCommand<HeartsAddCommand.Settings>
+{
+    public class Settings : HeartsSettings
+    {
+        [CommandOption("--tmdb-id <ID>")]
+        [Description("TMDB movie ID to add to hearts")]
+        public int? TmdbId { get; set; }
+
+        public override ValidationResult Validate()
+        {
+            if (TmdbId.HasValue && TmdbId.Value <= 0)
+            {
+                return ValidationResult.Error("TMDB ID must be a positive integer");
+            }
+
+            return ValidationResult.Success();
+        }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var csvService = new CsvService();
+
+        // Load existing data
+        var approvedFilms = await csvService.LoadApprovedFilmsAsync();
+        var hearts = await csvService.LoadHeartsAsync();
+
+        if (approvedFilms.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[yellow]No films in your log yet.[/] Add some films first with [green]filmstruck add[/].");
+            return 1;
+        }
+
+        int tmdbId;
+
+        if (settings.TmdbId.HasValue)
+        {
+            // Direct mode: use provided TMDB ID
+            tmdbId = settings.TmdbId.Value;
+
+            if (!approvedFilms.ContainsKey(tmdbId))
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] Film with TMDB ID {tmdbId} is not in your log.");
+                AnsiConsole.MarkupLine("[dim]You can only heart films you've already logged.[/]");
+                return 1;
+            }
+
+            if (hearts.Contains(tmdbId))
+            {
+                var film = approvedFilms[tmdbId];
+                AnsiConsole.MarkupLine($"[yellow]{Markup.Escape(film.Title)}[/] is already in your favorites.");
+                return 0;
+            }
+        }
+        else
+        {
+            // Interactive mode: select from logged films
+            var availableFilms = approvedFilms.Values
+                .Where(f => !hearts.Contains(f.TmdbId))
+                .OrderBy(f => f.Title)
+                .ToList();
+
+            if (availableFilms.Count == 0)
+            {
+                AnsiConsole.MarkupLine("[yellow]All your logged films are already in favorites![/]");
+                return 0;
+            }
+
+            var choices = availableFilms
+                .Select(f => $"{f.Title} ({f.ReleaseYear}) - {f.Director ?? "Unknown director"}")
+                .Concat(new[] { "<Cancel>" })
+                .ToList();
+
+            var selected = AnsiConsole.Prompt(
+                new SelectionPrompt<string>()
+                    .Title("Select a film to add to [red]favorites[/]:")
+                    .PageSize(15)
+                    .AddChoices(choices));
+
+            if (selected == "<Cancel>")
+            {
+                AnsiConsole.MarkupLine("[dim]Cancelled.[/]");
+                return 0;
+            }
+
+            var selectedIndex = choices.IndexOf(selected);
+            tmdbId = availableFilms[selectedIndex].TmdbId;
+        }
+
+        // Add to hearts
+        hearts.Add(tmdbId);
+        await csvService.WriteHeartsAsync(hearts);
+
+        var addedFilm = approvedFilms[tmdbId];
+        AnsiConsole.MarkupLine($"[red]♥[/] Added [green]{Markup.Escape(addedFilm.Title)}[/] to favorites.");
+
+        return 0;
+    }
+}

--- a/src/FilmStruck.Cli/Commands/Hearts/HeartsRemoveCommand.cs
+++ b/src/FilmStruck.Cli/Commands/Hearts/HeartsRemoveCommand.cs
@@ -1,0 +1,100 @@
+using System.ComponentModel;
+using FilmStruck.Cli.Services;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace FilmStruck.Cli.Commands.Hearts;
+
+public class HeartsRemoveCommand : AsyncCommand<HeartsRemoveCommand.Settings>
+{
+    public class Settings : HeartsSettings
+    {
+        [CommandOption("--tmdb-id <ID>")]
+        [Description("TMDB movie ID to remove from hearts")]
+        public int? TmdbId { get; set; }
+
+        public override ValidationResult Validate()
+        {
+            if (TmdbId.HasValue && TmdbId.Value <= 0)
+            {
+                return ValidationResult.Error("TMDB ID must be a positive integer");
+            }
+
+            return ValidationResult.Success();
+        }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var csvService = new CsvService();
+
+        // Load existing data
+        var approvedFilms = await csvService.LoadApprovedFilmsAsync();
+        var hearts = await csvService.LoadHeartsAsync();
+
+        if (hearts.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[yellow]No films in your favorites yet.[/]");
+            return 0;
+        }
+
+        int tmdbId;
+
+        if (settings.TmdbId.HasValue)
+        {
+            // Direct mode: use provided TMDB ID
+            tmdbId = settings.TmdbId.Value;
+
+            if (!hearts.Contains(tmdbId))
+            {
+                AnsiConsole.MarkupLine($"[yellow]Film with TMDB ID {tmdbId} is not in your favorites.[/]");
+                return 0;
+            }
+        }
+        else
+        {
+            // Interactive mode: select from hearted films
+            var heartedFilms = hearts
+                .Where(id => approvedFilms.ContainsKey(id))
+                .Select(id => approvedFilms[id])
+                .OrderBy(f => f.Title)
+                .ToList();
+
+            if (heartedFilms.Count == 0)
+            {
+                AnsiConsole.MarkupLine("[yellow]No films in your favorites yet.[/]");
+                return 0;
+            }
+
+            var choices = heartedFilms
+                .Select(f => $"{f.Title} ({f.ReleaseYear}) - {f.Director ?? "Unknown director"}")
+                .Concat(new[] { "<Cancel>" })
+                .ToList();
+
+            var selected = AnsiConsole.Prompt(
+                new SelectionPrompt<string>()
+                    .Title("Select a film to remove from [red]favorites[/]:")
+                    .PageSize(15)
+                    .AddChoices(choices));
+
+            if (selected == "<Cancel>")
+            {
+                AnsiConsole.MarkupLine("[dim]Cancelled.[/]");
+                return 0;
+            }
+
+            var selectedIndex = choices.IndexOf(selected);
+            tmdbId = heartedFilms[selectedIndex].TmdbId;
+        }
+
+        // Remove from hearts
+        hearts.Remove(tmdbId);
+        await csvService.WriteHeartsAsync(hearts);
+
+        var removedFilm = approvedFilms.GetValueOrDefault(tmdbId);
+        var filmName = removedFilm?.Title ?? $"TMDB ID {tmdbId}";
+        AnsiConsole.MarkupLine($"Removed [green]{Markup.Escape(filmName)}[/] from favorites.");
+
+        return 0;
+    }
+}

--- a/src/FilmStruck.Cli/Commands/Hearts/HeartsSettings.cs
+++ b/src/FilmStruck.Cli/Commands/Hearts/HeartsSettings.cs
@@ -1,0 +1,7 @@
+using Spectre.Console.Cli;
+
+namespace FilmStruck.Cli.Commands.Hearts;
+
+public class HeartsSettings : CommandSettings
+{
+}

--- a/src/FilmStruck.Cli/Program.cs
+++ b/src/FilmStruck.Cli/Program.cs
@@ -32,6 +32,9 @@ app.Configure(config =>
 
         hearts.AddCommand<HeartsAddCommand>("add")
             .WithDescription("Add a film to favorites");
+
+        hearts.AddCommand<HeartsRemoveCommand>("remove")
+            .WithDescription("Remove a film from favorites");
     });
 });
 

--- a/src/FilmStruck.Cli/Program.cs
+++ b/src/FilmStruck.Cli/Program.cs
@@ -1,4 +1,5 @@
 using FilmStruck.Cli.Commands;
+using FilmStruck.Cli.Commands.Hearts;
 using Spectre.Console.Cli;
 
 var app = new CommandApp();
@@ -24,6 +25,14 @@ app.Configure(config =>
 
     config.AddCommand<ImportLetterboxdCommand>("import-letterboxd-diary")
         .WithDescription("Import films from Letterboxd diary CSV export");
+
+    config.AddBranch<HeartsSettings>("hearts", hearts =>
+    {
+        hearts.SetDescription("Manage favorite films");
+
+        hearts.AddCommand<HeartsAddCommand>("add")
+            .WithDescription("Add a film to favorites");
+    });
 });
 
 return await app.RunAsync(args);


### PR DESCRIPTION
## Summary
- Add `hearts` command branch for managing favorite films
- Implement `hearts add` and `hearts remove` subcommands
- Both commands support interactive selection or `--tmdb-id` flag for direct usage

## Usage
```bash
# Add to favorites
filmstruck hearts add                  # Interactive: select from logged films
filmstruck hearts add --tmdb-id 550    # Direct: add specific film

# Remove from favorites
filmstruck hearts remove               # Interactive: select from favorites
filmstruck hearts remove --tmdb-id 550 # Direct: remove specific film
```

## Features
- Validates film exists in log before allowing heart
- Prevents duplicate hearts with friendly message
- Clear error messages for edge cases
- Updates README with hearts command documentation

## Test plan
- [ ] Run `filmstruck hearts --help` to verify commands registered
- [ ] Run `filmstruck hearts add --help` to verify flag documented
- [ ] Run `filmstruck hearts remove --help` to verify flag documented
- [ ] Test interactive add with logged films
- [ ] Test `hearts add --tmdb-id` with valid ID
- [ ] Test `hearts add --tmdb-id` with already-hearted film
- [ ] Test `hearts add --tmdb-id` with non-logged film
- [ ] Test interactive remove with hearted films
- [ ] Test `hearts remove --tmdb-id` with valid ID
- [ ] Test `hearts remove --tmdb-id` with non-hearted film

🤖 Generated with [Claude Code](https://claude.ai/code)