### PR TITLE
Add development infrastructure and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Run tests
+        env:
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+        run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ Thumbs.db
 .idea/
 *.swp
 *.swo
+
+# Test site
+test/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,21 @@ dotnet tool install --global --add-source ./nupkg FilmStruck.Cli
 
 **Environment:** Requires `TMDB_API_KEY` environment variable for TMDB commands.
 
+## Development Commands
+
+Use `make` for all development tasks:
+
+```bash
+make build      # Build the CLI
+make test       # Run integration tests
+make clean      # Clean build artifacts
+make reinstall  # Reinstall CLI globally
+make release VERSION=1.3.0  # Prepare a new release
+make help       # Show available commands
+```
+
+The test suite dynamically generates a test site, runs CLI commands against it, and cleans up afterward. Tests run with or without `TMDB_API_KEY` (TMDB-dependent tests are skipped if not set).
+
 ## Architecture
 
 FilmStruck is a .NET 9 CLI tool (Spectre.Console.Cli) that helps users track films with TMDB integration and generates a static site for GitHub Pages.
@@ -57,6 +72,7 @@ User → CLI commands → TMDB API → CSV files (data/) → CLI build → index
 
 1. Create `src/FilmStruck.Cli/Commands/YourCommand.cs` implementing `AsyncCommand<YourCommand.Settings>`
 2. Register in `Program.cs`: `config.AddCommand<YourCommand>("yourcommand").WithDescription("...");`
+3. **Add integration tests** in `scripts/test.sh` to verify the command works end-to-end
 
 ### Data Files
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,17 +34,25 @@ Thank you for your interest in contributing to FilmStruck!
 To test as a global tool:
 
 ```bash
+make reinstall
+```
+
+Or manually:
+```bash
 cd src/FilmStruck.Cli
 dotnet pack
 dotnet tool install --global --add-source ./nupkg FilmStruck.Cli
 ```
 
-To update after changes:
+### Development Commands
+
 ```bash
-cd src/FilmStruck.Cli
-dotnet tool uninstall --global FilmStruck.Cli
-dotnet pack
-dotnet tool install --global --add-source ./nupkg FilmStruck.Cli
+make build      # Build the CLI
+make test       # Run integration tests
+make clean      # Clean build artifacts
+make reinstall  # Reinstall CLI globally
+make release VERSION=1.3.0  # Prepare a new release
+make help       # Show all commands
 ```
 
 ## Project Structure
@@ -108,6 +116,7 @@ Placeholders:
    config.AddCommand<YourCommand>("yourcommand")
        .WithDescription("Description here");
    ```
+4. **Add integration tests** in `scripts/test.sh` (see Testing section)
 
 ### Modifying the Site Output
 
@@ -128,21 +137,33 @@ Placeholders:
 
 ## Testing
 
-Currently there are no automated tests. Manual testing:
+Run the integration test suite:
 
 ```bash
-# Create a test directory
-mkdir /tmp/test-fs && cd /tmp/test-fs && git init
-
-# Test init
-dotnet run --project /path/to/filmstruck/src/FilmStruck.Cli -- init -u testuser
-
-# Test build (should work with empty data)
-dotnet run --project /path/to/filmstruck/src/FilmStruck.Cli -- build
-
-# Verify output
-open index.html  # Should show "testuser" as the username
+make test
 ```
+
+The test suite:
+- Dynamically creates a test site with sample data
+- Runs `enrich`, `calculate`, `add`, and `build` commands
+- Validates expected outputs (files created, data updated)
+- Cleans up automatically
+
+Tests requiring TMDB API access are skipped if `TMDB_API_KEY` is not set. To run the full suite:
+
+```bash
+export TMDB_API_KEY="your-api-key"
+make test
+```
+
+### Adding Integration Tests
+
+**All new commands must have integration tests.** When adding a command:
+
+1. Add a test section in `scripts/test.sh`
+2. Test both success and expected outputs
+3. Use non-interactive flags for CI compatibility
+4. Verify file changes where applicable
 
 ## Submitting Changes
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: build test clean reinstall release help
+
+build:
+	dotnet build src/FilmStruck.Cli/FilmStruck.Cli.csproj
+
+test:
+	./scripts/test.sh
+
+clean:
+	./scripts/clean.sh
+
+reinstall:
+	./scripts/reinstall.sh
+
+release:
+	@test -n "$(VERSION)" || (echo "Usage: make release VERSION=1.3.0" && exit 1)
+	./scripts/prepare-release.sh $(VERSION)
+
+help:
+	@echo "make build     - Build the CLI"
+	@echo "make test      - Run tests"
+	@echo "make clean     - Clean build artifacts"
+	@echo "make reinstall - Reinstall CLI globally"
+	@echo "make release   - Prepare release (VERSION=x.y.z)"

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Clean build artifacts
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+
+echo "Cleaning build artifacts..."
+
+rm -rf "$REPO_ROOT/src/FilmStruck.Cli/bin"
+rm -rf "$REPO_ROOT/src/FilmStruck.Cli/obj"
+rm -rf "$REPO_ROOT/src/FilmStruck.Cli/nupkg"
+rm -rf "$REPO_ROOT/test"
+
+echo "Done!"

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Prepare a new release: update version, changelog, create branch and PR
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+CSPROJ="$REPO_ROOT/src/FilmStruck.Cli/FilmStruck.Cli.csproj"
+CHANGELOG="$REPO_ROOT/CHANGELOG.md"
+
+# Get version from argument or prompt
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+    read -p "Enter new version (e.g., 1.3.0): " VERSION
+fi
+
+# Validate version format
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Invalid version format. Use semver (e.g., 1.3.0)"
+    exit 1
+fi
+
+# Check for uncommitted changes
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "Error: You have uncommitted changes. Commit or stash them first."
+    exit 1
+fi
+
+# Make sure we're on main and up to date
+git checkout main
+git pull origin main
+
+# Create release branch
+BRANCH="release/v$VERSION"
+echo "Creating branch $BRANCH..."
+git checkout -b "$BRANCH"
+
+# Update version in .csproj
+sed -i '' "s|<Version>.*</Version>|<Version>$VERSION</Version>|" "$CSPROJ"
+
+# Update CHANGELOG.md - add new section after header
+DATE=$(date +%Y-%m-%d)
+# Create temp file with new changelog content
+{
+    head -1 "$CHANGELOG"
+    echo ""
+    echo "## [$VERSION] - $DATE"
+    echo ""
+    echo "### Added"
+    echo ""
+    echo "### Changed"
+    echo ""
+    echo "### Fixed"
+    echo ""
+    tail -n +2 "$CHANGELOG"
+} > "$CHANGELOG.tmp"
+mv "$CHANGELOG.tmp" "$CHANGELOG"
+
+echo "Updated .csproj and CHANGELOG.md"
+echo ""
+echo "Please edit CHANGELOG.md to add release notes, then press Enter to continue..."
+read -p ""
+
+# Commit and push
+git add "$CSPROJ" "$CHANGELOG"
+git commit -m "Prepare release v$VERSION"
+git push -u origin "$BRANCH"
+
+# Create PR using gh CLI
+echo "Creating pull request..."
+gh pr create \
+    --title "Prepare release v$VERSION" \
+    --body "## Release v$VERSION
+
+- Updates version to $VERSION
+- Updates CHANGELOG.md
+
+After merging, create a GitHub release with tag \`v$VERSION\` to publish to NuGet." \
+    --base main
+
+echo ""
+echo "Done! PR created."
+echo ""
+echo "Next steps:"
+echo "1. Review and merge the PR"
+echo "2. Create a GitHub release with tag v$VERSION"
+echo "   https://github.com/shreshthkhilani/filmstruck/releases/new?tag=v$VERSION"

--- a/scripts/reinstall.sh
+++ b/scripts/reinstall.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Uninstall, build, pack, and reinstall FilmStruck CLI for testing
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$SCRIPT_DIR/../src/FilmStruck.Cli"
+
+echo "Uninstalling existing FilmStruck.Cli..."
+dotnet tool uninstall --global FilmStruck.Cli 2>/dev/null || true
+
+echo "Building..."
+dotnet build "$PROJECT_DIR/FilmStruck.Cli.csproj"
+
+echo "Packing..."
+dotnet pack "$PROJECT_DIR/FilmStruck.Cli.csproj" --output "$PROJECT_DIR/nupkg"
+
+echo "Installing..."
+dotnet tool install --global --add-source "$PROJECT_DIR/nupkg" FilmStruck.Cli
+
+echo "Done! Run 'filmstruck --help' to verify."

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# Build CLI and run comprehensive tests against a dynamically generated test site
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+PROJECT="$REPO_ROOT/src/FilmStruck.Cli/FilmStruck.Cli.csproj"
+TEST_SITE="$REPO_ROOT/test/sample-site"
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+# Test counters
+PASSED=0
+FAILED=0
+SKIPPED=0
+FAILED_TESTS=""
+
+pass() {
+    PASSED=$((PASSED + 1))
+}
+
+fail() {
+    FAILED=$((FAILED + 1))
+    FAILED_TESTS="$FAILED_TESTS\n  - $1"
+}
+
+skip() {
+    SKIPPED=$((SKIPPED + 1))
+}
+
+run_command() {
+    dotnet run --project "$PROJECT" -v quiet -- "$@" 2>&1
+}
+
+setup_test_site() {
+    rm -rf "$TEST_SITE"
+    mkdir -p "$TEST_SITE/data"
+
+    # Initialize git repo (required by CsvService)
+    cd "$TEST_SITE"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test"
+
+    # Create config
+    cat > filmstruck.json << 'EOF'
+{
+  "username": "testuser",
+  "siteTitle": "Test Film Log"
+}
+EOF
+
+    # Create log.csv with sample films (tmdbId known for testing)
+    cat > data/log.csv << 'EOF'
+date,title,location,companions,tmdbId
+1/15/2024,The Godfather,Home,,238
+1/20/2024,Pulp Fiction,Theater,Alice,680
+2/1/2024,Inception,Home,Bob,27205
+EOF
+}
+
+cleanup() {
+    rm -rf "$TEST_SITE" 2>/dev/null || true
+}
+
+print_summary() {
+    echo ""
+    echo -e "${BOLD}Test Results${NC}"
+    echo "─────────────────────────────"
+
+    TOTAL=$((PASSED + FAILED + SKIPPED))
+
+    if [ $PASSED -gt 0 ]; then
+        echo -e "${GREEN}✓ $PASSED passed${NC}"
+    fi
+
+    if [ $SKIPPED -gt 0 ]; then
+        echo -e "${YELLOW}○ $SKIPPED skipped${NC}"
+    fi
+
+    if [ $FAILED -gt 0 ]; then
+        echo -e "${RED}✗ $FAILED failed${NC}"
+        echo -e "${RED}Failed tests:$FAILED_TESTS${NC}"
+    fi
+
+    echo ""
+
+    if [ $FAILED -gt 0 ]; then
+        exit 1
+    fi
+}
+
+# Trap to ensure cleanup on exit
+trap cleanup EXIT
+
+# Build quietly
+dotnet build "$PROJECT" -v quiet
+
+setup_test_site
+cd "$TEST_SITE"
+
+# Test 1: enrich command (creates films.csv from log.csv)
+if [ -n "$TMDB_API_KEY" ]; then
+    rm -f data/films.csv
+    OUTPUT=$(run_command enrich --default-poster 2>&1) || true
+    if [ -f "data/films.csv" ] && [ $(wc -l < data/films.csv) -gt 1 ]; then
+        pass "enrich"
+    else
+        fail "enrich: films.csv not created or empty"
+    fi
+else
+    skip "enrich"
+    # Create films.csv manually for subsequent tests
+    cat > data/films.csv << 'EOF'
+tmdbId,title,director,releaseYear,language,posterPath
+238,The Godfather,Francis Ford Coppola,1972,en,/3bhkrj58Vtu7enYsRolD1fZdja1.jpg
+680,Pulp Fiction,Quentin Tarantino,1994,en,/d5iIlFn5s0ImszYzBPb8JPIfbXD.jpg
+27205,Inception,Christopher Nolan,2010,en,/oYuLEt3zVCKq57qu2F8dT7NIa6f.jpg
+EOF
+fi
+
+# Test 2: calculate command (creates stats.csv)
+rm -f data/stats.csv
+OUTPUT=$(run_command calculate 2>&1) || true
+if [ -f "data/stats.csv" ] && [ $(wc -l < data/stats.csv) -gt 1 ]; then
+    pass "calculate"
+else
+    fail "calculate: stats.csv not created or empty"
+fi
+
+# Test 3: add command (requires TMDB_API_KEY)
+if [ -n "$TMDB_API_KEY" ]; then
+    LOG_LINES_BEFORE=$(wc -l < data/log.csv)
+    OUTPUT=$(run_command add --title "The Matrix" --tmdb-id 603 --date "3/1/2024" --location "Home" --companions "" --default-poster 2>&1) || true
+    LOG_LINES_AFTER=$(wc -l < data/log.csv)
+
+    if [ "$LOG_LINES_AFTER" -gt "$LOG_LINES_BEFORE" ]; then
+        pass "add: log.csv updated"
+    else
+        fail "add: log.csv not updated"
+    fi
+
+    # Verify films.csv has The Matrix (tmdbId 603)
+    if grep -q "603" data/films.csv; then
+        pass "add: films.csv updated"
+    else
+        fail "add: films.csv not updated"
+    fi
+else
+    skip "add"
+fi
+
+# Test 4: build command (creates index.html)
+rm -f index.html
+OUTPUT=$(run_command build 2>&1) || true
+if [ -f "index.html" ]; then
+    pass "build"
+else
+    fail "build: index.html not generated"
+fi
+
+print_summary


### PR DESCRIPTION
## Summary

- Add **Makefile** with common development commands (`make build`, `make test`, `make clean`, `make reinstall`, `make release`)
- Add **GitHub Actions CI workflow** that runs tests on push and PRs to main
- Add **integration test suite** (`scripts/test.sh`) with clean summary output
- Add helper scripts for clean, reinstall, and release preparation
- Add `--default-poster` flag to enrich command for non-interactive CI testing
- Update documentation (CLAUDE.md, CONTRIBUTING.md) with development workflow

## Test plan

- [x] `make test` passes locally (2 passed, 2 skipped without TMDB_API_KEY)
- [ ] CI workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.ai/code)