### PR TITLE
Add unit test infrastructure with NUnit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ on:
     branches: [main]
 
 jobs:
-  build-and-test:
+  unit-tests:
+    name: Unit Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -26,6 +27,21 @@ jobs:
 
       - name: Run unit tests
         run: make unit-test
+
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Build
+        run: dotnet build src/FilmStruck.Cli/FilmStruck.Cli.csproj
 
       - name: Run integration tests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,16 @@ jobs:
         with:
           dotnet-version: '9.0.x'
 
-      - name: Run tests
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore
+
+      - name: Run unit tests
+        run: make unit-test
+
+      - name: Run integration tests
         env:
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
-        run: make test
+        run: make integration-test

--- a/FilmStruck.sln
+++ b/FilmStruck.sln
@@ -1,0 +1,56 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FilmStruck.Cli", "src\FilmStruck.Cli\FilmStruck.Cli.csproj", "{337ACE13-AD54-459E-9E4F-FEC4C60B1F13}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FilmStruck.Cli.Tests", "tests\FilmStruck.Cli.Tests\FilmStruck.Cli.Tests.csproj", "{0394D536-A88F-4506-A82F-78CDD6687C25}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{337ACE13-AD54-459E-9E4F-FEC4C60B1F13}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{337ACE13-AD54-459E-9E4F-FEC4C60B1F13}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{337ACE13-AD54-459E-9E4F-FEC4C60B1F13}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{337ACE13-AD54-459E-9E4F-FEC4C60B1F13}.Debug|x64.Build.0 = Debug|Any CPU
+		{337ACE13-AD54-459E-9E4F-FEC4C60B1F13}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{337ACE13-AD54-459E-9E4F-FEC4C60B1F13}.Debug|x86.Build.0 = Debug|Any CPU
+		{337ACE13-AD54-459E-9E4F-FEC4C60B1F13}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{337ACE13-AD54-459E-9E4F-FEC4C60B1F13}.Release|Any CPU.Build.0 = Release|Any CPU
+		{337ACE13-AD54-459E-9E4F-FEC4C60B1F13}.Release|x64.ActiveCfg = Release|Any CPU
+		{337ACE13-AD54-459E-9E4F-FEC4C60B1F13}.Release|x64.Build.0 = Release|Any CPU
+		{337ACE13-AD54-459E-9E4F-FEC4C60B1F13}.Release|x86.ActiveCfg = Release|Any CPU
+		{337ACE13-AD54-459E-9E4F-FEC4C60B1F13}.Release|x86.Build.0 = Release|Any CPU
+		{0394D536-A88F-4506-A82F-78CDD6687C25}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0394D536-A88F-4506-A82F-78CDD6687C25}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0394D536-A88F-4506-A82F-78CDD6687C25}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0394D536-A88F-4506-A82F-78CDD6687C25}.Debug|x64.Build.0 = Debug|Any CPU
+		{0394D536-A88F-4506-A82F-78CDD6687C25}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0394D536-A88F-4506-A82F-78CDD6687C25}.Debug|x86.Build.0 = Debug|Any CPU
+		{0394D536-A88F-4506-A82F-78CDD6687C25}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0394D536-A88F-4506-A82F-78CDD6687C25}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0394D536-A88F-4506-A82F-78CDD6687C25}.Release|x64.ActiveCfg = Release|Any CPU
+		{0394D536-A88F-4506-A82F-78CDD6687C25}.Release|x64.Build.0 = Release|Any CPU
+		{0394D536-A88F-4506-A82F-78CDD6687C25}.Release|x86.ActiveCfg = Release|Any CPU
+		{0394D536-A88F-4506-A82F-78CDD6687C25}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{337ACE13-AD54-459E-9E4F-FEC4C60B1F13} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{0394D536-A88F-4506-A82F-78CDD6687C25} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+	EndGlobalSection
+EndGlobal

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
-.PHONY: build test clean reinstall release help
+.PHONY: build test unit-test integration-test clean reinstall release help
 
 build:
 	dotnet build src/FilmStruck.Cli/FilmStruck.Cli.csproj
 
-test:
+test: unit-test integration-test
+
+unit-test:
+	dotnet test tests/FilmStruck.Cli.Tests/FilmStruck.Cli.Tests.csproj --verbosity normal
+
+integration-test:
 	./scripts/test.sh
 
 clean:
@@ -17,8 +22,10 @@ release:
 	./scripts/prepare-release.sh $(VERSION)
 
 help:
-	@echo "make build     - Build the CLI"
-	@echo "make test      - Run tests"
-	@echo "make clean     - Clean build artifacts"
-	@echo "make reinstall - Reinstall CLI globally"
-	@echo "make release   - Prepare release (VERSION=x.y.z)"
+	@echo "make build            - Build the CLI"
+	@echo "make test             - Run all tests (unit + integration)"
+	@echo "make unit-test        - Run unit tests only"
+	@echo "make integration-test - Run integration tests only"
+	@echo "make clean            - Clean build artifacts"
+	@echo "make reinstall        - Reinstall CLI globally"
+	@echo "make release          - Prepare release (VERSION=x.y.z)"

--- a/src/FilmStruck.Cli/FilmStruck.Cli.csproj
+++ b/src/FilmStruck.Cli/FilmStruck.Cli.csproj
@@ -29,6 +29,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="FilmStruck.Cli.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
   </ItemGroup>

--- a/src/FilmStruck.Cli/Services/TmdbService.cs
+++ b/src/FilmStruck.Cli/Services/TmdbService.cs
@@ -13,6 +13,12 @@ public class TmdbService : IDisposable
         _http.DefaultRequestHeaders.Add("Accept", "application/json");
     }
 
+    // Constructor for testing with injected HttpClient
+    public TmdbService(HttpClient httpClient)
+    {
+        _http = httpClient;
+    }
+
     public async Task<List<TmdbMovie>> SearchMoviesAsync(string title)
     {
         var encoded = Uri.EscapeDataString(title);

--- a/tests/FilmStruck.Cli.Tests/FilmStruck.Cli.Tests.csproj
+++ b/tests/FilmStruck.Cli.Tests/FilmStruck.Cli.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/FilmStruck.Cli/FilmStruck.Cli.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/FilmStruck.Cli.Tests/Helpers/MockHttpHandler.cs
+++ b/tests/FilmStruck.Cli.Tests/Helpers/MockHttpHandler.cs
@@ -1,0 +1,50 @@
+using System.Net;
+
+namespace FilmStruck.Cli.Tests.Helpers;
+
+public class MockHttpHandler : HttpMessageHandler
+{
+    private readonly Dictionary<string, HttpResponseMessage> _responses = new();
+    private Func<HttpRequestMessage, HttpResponseMessage>? _responseFactory;
+
+    public void SetResponse(string urlPattern, HttpResponseMessage response)
+    {
+        _responses[urlPattern] = response;
+    }
+
+    public void SetResponse(string urlPattern, string jsonContent, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        _responses[urlPattern] = new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(jsonContent, System.Text.Encoding.UTF8, "application/json")
+        };
+    }
+
+    public void SetResponseFactory(Func<HttpRequestMessage, HttpResponseMessage> factory)
+    {
+        _responseFactory = factory;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        if (_responseFactory != null)
+        {
+            return Task.FromResult(_responseFactory(request));
+        }
+
+        var url = request.RequestUri?.ToString() ?? "";
+
+        foreach (var kvp in _responses)
+        {
+            if (url.Contains(kvp.Key))
+            {
+                return Task.FromResult(kvp.Value);
+            }
+        }
+
+        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent($"No mock response configured for: {url}")
+        });
+    }
+}

--- a/tests/FilmStruck.Cli.Tests/Services/ConfigServiceTests.cs
+++ b/tests/FilmStruck.Cli.Tests/Services/ConfigServiceTests.cs
@@ -1,0 +1,68 @@
+using FilmStruck.Cli.Services;
+using NUnit.Framework;
+
+namespace FilmStruck.Cli.Tests.Services;
+
+[TestFixture]
+public class ConfigServiceTests
+{
+    private string _tempDir = null!;
+    private ConfigService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"filmstruck-config-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+        _service = new ConfigService();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public void LoadConfig_ReturnsDefaultWhenNoFile()
+    {
+        var config = _service.LoadConfig(_tempDir);
+
+        Assert.That(config.Username, Is.EqualTo("user"));
+        Assert.That(config.SiteTitle, Is.EqualTo("filmstruck"));
+    }
+
+    [Test]
+    public void LoadConfig_ParsesJson()
+    {
+        var configPath = Path.Combine(_tempDir, "filmstruck.json");
+        File.WriteAllText(configPath, @"{
+            ""username"": ""myname"",
+            ""siteTitle"": ""My Film Log""
+        }");
+
+        var config = _service.LoadConfig(_tempDir);
+
+        Assert.That(config.Username, Is.EqualTo("myname"));
+        Assert.That(config.SiteTitle, Is.EqualTo("My Film Log"));
+    }
+
+    [Test]
+    public void SaveConfig_RoundTrips()
+    {
+        var original = new FilmStruckConfig
+        {
+            Username = "testuser",
+            SiteTitle = "Test Site"
+        };
+
+        _service.SaveConfig(original, _tempDir);
+        var loaded = _service.LoadConfig(_tempDir);
+
+        Assert.That(loaded.Username, Is.EqualTo(original.Username));
+        Assert.That(loaded.SiteTitle, Is.EqualTo(original.SiteTitle));
+    }
+}

--- a/tests/FilmStruck.Cli.Tests/Services/CsvServiceTests.cs
+++ b/tests/FilmStruck.Cli.Tests/Services/CsvServiceTests.cs
@@ -1,0 +1,174 @@
+using FilmStruck.Cli;
+using FilmStruck.Cli.Services;
+using NUnit.Framework;
+
+namespace FilmStruck.Cli.Tests.Services;
+
+[TestFixture]
+public class CsvServiceTests
+{
+    private string _tempDir = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"filmstruck-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+        Directory.CreateDirectory(Path.Combine(_tempDir, ".git"));
+        Directory.CreateDirectory(Path.Combine(_tempDir, "data"));
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    private CsvService CreateService()
+    {
+        var originalDir = Directory.GetCurrentDirectory();
+        try
+        {
+            Directory.SetCurrentDirectory(_tempDir);
+            return new CsvService();
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalDir);
+        }
+    }
+
+    [Test]
+    public async Task LoadLogAsync_ParsesBasicCsv()
+    {
+        var logPath = Path.Combine(_tempDir, "data", "log.csv");
+        await File.WriteAllTextAsync(logPath, @"date,title,location,companions,tmdbId
+1/15/2024,Inception,Home,Alice,27205
+1/16/2024,The Matrix,Theater,Bob,603");
+
+        var service = CreateService();
+        var films = await service.LoadLogAsync();
+
+        Assert.That(films.Count, Is.EqualTo(2));
+        Assert.That(films[0].Title, Is.EqualTo("Inception"));
+        Assert.That(films[0].Date, Is.EqualTo("1/15/2024"));
+        Assert.That(films[0].Location, Is.EqualTo("Home"));
+        Assert.That(films[0].Companions, Is.EqualTo("Alice"));
+        Assert.That(films[0].TmdbId, Is.EqualTo(27205));
+        Assert.That(films[1].Title, Is.EqualTo("The Matrix"));
+        Assert.That(films[1].TmdbId, Is.EqualTo(603));
+    }
+
+    [TestCase("\"Alice,Bob\"", "Alice,Bob")]
+    [TestCase("\"Film with \"\"quotes\"\"\"", "Film with quotes")]
+    public async Task LoadLogAsync_HandlesQuotedFields(string quotedValue, string expected)
+    {
+        var logPath = Path.Combine(_tempDir, "data", "log.csv");
+        await File.WriteAllTextAsync(logPath, $@"date,title,location,companions,tmdbId
+1/15/2024,Test Film,Home,{quotedValue},123");
+
+        var service = CreateService();
+        var films = await service.LoadLogAsync();
+
+        Assert.That(films.Count, Is.EqualTo(1));
+        // The quoted value is in companions field
+        Assert.That(films[0].Companions, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task LoadLogAsync_HandlesEmptyFile()
+    {
+        var logPath = Path.Combine(_tempDir, "data", "log.csv");
+        await File.WriteAllTextAsync(logPath, "date,title,location,companions,tmdbId");
+
+        var service = CreateService();
+        var films = await service.LoadLogAsync();
+
+        Assert.That(films, Is.Empty);
+    }
+
+    [Test]
+    public async Task LoadApprovedFilmsAsync_ParsesAllFields()
+    {
+        var filmsPath = Path.Combine(_tempDir, "data", "films.csv");
+        await File.WriteAllTextAsync(filmsPath, @"tmdbId,title,director,releaseYear,language,posterPath
+27205,Inception,Christopher Nolan,2010,en,/poster1.jpg
+603,The Matrix,Lana Wachowski,1999,en,/poster2.jpg");
+
+        var service = CreateService();
+        var films = await service.LoadApprovedFilmsAsync();
+
+        Assert.That(films.Count, Is.EqualTo(2));
+        Assert.That(films[27205].Title, Is.EqualTo("Inception"));
+        Assert.That(films[27205].Director, Is.EqualTo("Christopher Nolan"));
+        Assert.That(films[27205].ReleaseYear, Is.EqualTo("2010"));
+        Assert.That(films[27205].Language, Is.EqualTo("en"));
+        Assert.That(films[27205].PosterPath, Is.EqualTo("/poster1.jpg"));
+    }
+
+    [Test]
+    public async Task LoadApprovedFilmsAsync_ReturnsEmptyWhenNoFile()
+    {
+        var service = CreateService();
+        var films = await service.LoadApprovedFilmsAsync();
+
+        Assert.That(films, Is.Empty);
+    }
+
+    [Test]
+    public async Task LoadHeartsAsync_ParsesIds()
+    {
+        var heartsPath = Path.Combine(_tempDir, "data", "hearts.csv");
+        await File.WriteAllTextAsync(heartsPath, @"tmdbId
+27205
+603
+278");
+
+        var service = CreateService();
+        var hearts = await service.LoadHeartsAsync();
+
+        Assert.That(hearts.Count, Is.EqualTo(3));
+        Assert.That(hearts.Contains(27205), Is.True);
+        Assert.That(hearts.Contains(603), Is.True);
+        Assert.That(hearts.Contains(278), Is.True);
+    }
+
+    [Test]
+    public async Task WriteLogAsync_QuotesFieldsWithCommas()
+    {
+        var service = CreateService();
+        var films = new List<Film>
+        {
+            new Film("1/15/2024", "Test Film", "Home", "Alice,Bob", 123)
+        };
+
+        await service.WriteLogAsync(films);
+
+        var content = await File.ReadAllTextAsync(service.LogPath);
+        Assert.That(content, Does.Contain("\"Alice,Bob\""));
+    }
+
+    [Test]
+    public void GetRecentLocations_OrdersByFrequency()
+    {
+        var films = new List<Film>
+        {
+            new Film("1/1/2024", "Film 1", "Home", "", null),
+            new Film("1/2/2024", "Film 2", "Home", "", null),
+            new Film("1/3/2024", "Film 3", "Home", "", null),
+            new Film("1/4/2024", "Film 4", "Theater", "", null),
+            new Film("1/5/2024", "Film 5", "Theater", "", null),
+            new Film("1/6/2024", "Film 6", "Airplane", "", null)
+        };
+
+        var service = CreateService();
+        var locations = service.GetRecentLocations(films);
+
+        Assert.That(locations[0], Is.EqualTo("Home"));
+        Assert.That(locations[1], Is.EqualTo("Theater"));
+        Assert.That(locations[2], Is.EqualTo("Airplane"));
+    }
+}

--- a/tests/FilmStruck.Cli.Tests/Services/SiteGeneratorServiceTests.cs
+++ b/tests/FilmStruck.Cli.Tests/Services/SiteGeneratorServiceTests.cs
@@ -1,0 +1,76 @@
+using FilmStruck.Cli;
+using FilmStruck.Cli.Services;
+using NUnit.Framework;
+
+namespace FilmStruck.Cli.Tests.Services;
+
+[TestFixture]
+public class SiteGeneratorServiceTests
+{
+    private SiteGeneratorService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _service = new SiteGeneratorService();
+    }
+
+    [Test]
+    public void GenerateHtml_ReplacesUsernameToken()
+    {
+        var films = new List<WatchedFilm>();
+        var companions = new List<CompanionCount>();
+        var hearts = new HashSet<int>();
+        var config = new FilmStruckConfig { Username = "testuser", SiteTitle = "filmstruck" };
+
+        var html = _service.GenerateHtml(films, companions, hearts, config);
+
+        Assert.That(html, Does.Not.Contain("{{USERNAME}}"));
+        Assert.That(html, Does.Contain("testuser"));
+    }
+
+    [Test]
+    public void GenerateHtml_EmbedsFilmsAsJson()
+    {
+        var films = new List<WatchedFilm>
+        {
+            new WatchedFilm(
+                "1/15/2024",
+                "Home",
+                "Alice",
+                "27205",
+                "Inception",
+                "2010",
+                "Christopher Nolan",
+                "en",
+                "/poster.jpg"
+            )
+        };
+        var companions = new List<CompanionCount>();
+        var hearts = new HashSet<int>();
+        var config = new FilmStruckConfig { Username = "testuser" };
+
+        var html = _service.GenerateHtml(films, companions, hearts, config);
+
+        Assert.That(html, Does.Not.Contain("{{FILMS_DATA}}"));
+        Assert.That(html, Does.Contain("Inception"));
+        Assert.That(html, Does.Contain("27205"));
+        Assert.That(html, Does.Contain("Christopher Nolan"));
+    }
+
+    [Test]
+    public void GenerateHtml_EmbedsHeartsAsJson()
+    {
+        var films = new List<WatchedFilm>();
+        var companions = new List<CompanionCount>();
+        var hearts = new HashSet<int> { 27205, 603, 278 };
+        var config = new FilmStruckConfig { Username = "testuser" };
+
+        var html = _service.GenerateHtml(films, companions, hearts, config);
+
+        Assert.That(html, Does.Not.Contain("{{HEARTS_DATA}}"));
+        Assert.That(html, Does.Contain("27205"));
+        Assert.That(html, Does.Contain("603"));
+        Assert.That(html, Does.Contain("278"));
+    }
+}

--- a/tests/FilmStruck.Cli.Tests/Services/StatsServiceTests.cs
+++ b/tests/FilmStruck.Cli.Tests/Services/StatsServiceTests.cs
@@ -1,0 +1,140 @@
+using FilmStruck.Cli;
+using FilmStruck.Cli.Services;
+using NUnit.Framework;
+
+namespace FilmStruck.Cli.Tests.Services;
+
+[TestFixture]
+public class StatsServiceTests
+{
+    private StatsService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _service = new StatsService();
+    }
+
+    [Test]
+    public void CalculateStats_EmptyLog_ReturnsEmptyStats()
+    {
+        var log = new List<Film>();
+        var films = new Dictionary<int, ApprovedFilm>();
+
+        var stats = _service.CalculateStats(log, films);
+
+        Assert.That(stats["watch_year"], Is.Empty);
+        Assert.That(stats["director"], Is.Empty);
+        Assert.That(stats["companion"], Is.Empty);
+        Assert.That(stats["location"], Is.Empty);
+        Assert.That(stats["release_decade"], Is.Empty);
+    }
+
+    [TestCase("1/15/2024", 2024)]
+    [TestCase("12/31/2023", 2023)]
+    [TestCase("6/1/2020", 2020)]
+    public void CalculateStats_ParsesWatchYear(string date, int expectedYear)
+    {
+        var log = new List<Film> { new Film(date, "Test Film", "Home", "", 123) };
+        var films = new Dictionary<int, ApprovedFilm>();
+
+        var stats = _service.CalculateStats(log, films);
+
+        Assert.That(stats["watch_year"].ContainsKey(expectedYear.ToString()), Is.True);
+        Assert.That(stats["watch_year"][expectedYear.ToString()], Is.EqualTo(1));
+    }
+
+    [TestCase("Alice,Bob", new[] { "Alice", "Bob" })]
+    [TestCase("Alice", new[] { "Alice" })]
+    [TestCase("", new string[0])]
+    [TestCase("  Alice  ,  Bob  ", new[] { "Alice", "Bob" })]
+    public void CalculateStats_SplitsCompanions(string companions, string[] expected)
+    {
+        var log = new List<Film> { new Film("1/1/2024", "Test Film", "Home", companions, null) };
+        var films = new Dictionary<int, ApprovedFilm>();
+
+        var stats = _service.CalculateStats(log, films);
+
+        foreach (var companion in expected)
+        {
+            Assert.That(stats["companion"].ContainsKey(companion), Is.True);
+            Assert.That(stats["companion"][companion], Is.EqualTo(1));
+        }
+        Assert.That(stats["companion"].Count, Is.EqualTo(expected.Length));
+    }
+
+    [TestCase(1972, "1970s")]
+    [TestCase(2024, "2020s")]
+    [TestCase(1999, "1990s")]
+    [TestCase(2000, "2000s")]
+    public void CalculateStats_CalculatesDecade(int releaseYear, string expectedDecade)
+    {
+        var log = new List<Film> { new Film("1/1/2024", "Test Film", "Home", "", 123) };
+        var films = new Dictionary<int, ApprovedFilm>
+        {
+            [123] = new ApprovedFilm(123, "Test Film", "Director", releaseYear.ToString(), "en", "/poster.jpg")
+        };
+
+        var stats = _service.CalculateStats(log, films);
+
+        Assert.That(stats["release_decade"].ContainsKey(expectedDecade), Is.True);
+        Assert.That(stats["release_decade"][expectedDecade], Is.EqualTo(1));
+    }
+
+    [Test]
+    public void CalculateStats_CountsDirectors()
+    {
+        var log = new List<Film>
+        {
+            new Film("1/1/2024", "Film 1", "Home", "", 1),
+            new Film("1/2/2024", "Film 2", "Home", "", 2),
+            new Film("1/3/2024", "Film 3", "Home", "", 3)
+        };
+        var films = new Dictionary<int, ApprovedFilm>
+        {
+            [1] = new ApprovedFilm(1, "Film 1", "Nolan", "2020", "en", null),
+            [2] = new ApprovedFilm(2, "Film 2", "Nolan", "2021", "en", null),
+            [3] = new ApprovedFilm(3, "Film 3", "Spielberg", "2022", "en", null)
+        };
+
+        var stats = _service.CalculateStats(log, films);
+
+        Assert.That(stats["director"]["Nolan"], Is.EqualTo(2));
+        Assert.That(stats["director"]["Spielberg"], Is.EqualTo(1));
+    }
+
+    [Test]
+    public void CalculateStats_CountsLocations()
+    {
+        var log = new List<Film>
+        {
+            new Film("1/1/2024", "Film 1", "Home", "", null),
+            new Film("1/2/2024", "Film 2", "Home", "", null),
+            new Film("1/3/2024", "Film 3", "Theater", "", null)
+        };
+        var films = new Dictionary<int, ApprovedFilm>();
+
+        var stats = _service.CalculateStats(log, films);
+
+        Assert.That(stats["location"]["Home"], Is.EqualTo(2));
+        Assert.That(stats["location"]["Theater"], Is.EqualTo(1));
+    }
+
+    [Test]
+    public void CalculateStats_CountsAllTime()
+    {
+        var log = new List<Film>
+        {
+            new Film("1/1/2023", "Film 1", "Home", "", null),
+            new Film("1/1/2024", "Film 2", "Home", "", null),
+            new Film("6/1/2024", "Film 3", "Home", "", null)
+        };
+        var films = new Dictionary<int, ApprovedFilm>();
+
+        var stats = _service.CalculateStats(log, films);
+
+        Assert.That(stats["watch_year"]["ALL_TIME"], Is.EqualTo(3));
+        Assert.That(stats["watch_year"]["2024"], Is.EqualTo(2));
+        Assert.That(stats["watch_year"]["2023"], Is.EqualTo(1));
+    }
+}

--- a/tests/FilmStruck.Cli.Tests/Services/TmdbServiceTests.cs
+++ b/tests/FilmStruck.Cli.Tests/Services/TmdbServiceTests.cs
@@ -1,0 +1,103 @@
+using FilmStruck.Cli.Services;
+using FilmStruck.Cli.Tests.Helpers;
+using NUnit.Framework;
+
+namespace FilmStruck.Cli.Tests.Services;
+
+[TestFixture]
+public class TmdbServiceTests
+{
+    private MockHttpHandler _mockHandler = null!;
+    private TmdbService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockHandler = new MockHttpHandler();
+        var httpClient = new HttpClient(_mockHandler);
+        _service = new TmdbService(httpClient);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _service.Dispose();
+    }
+
+    [Test]
+    public async Task SearchMoviesAsync_ReturnsResults()
+    {
+        _mockHandler.SetResponse("search/movie", @"{
+            ""results"": [
+                { ""id"": 27205, ""title"": ""Inception"", ""release_date"": ""2010-07-16"", ""original_language"": ""en"" },
+                { ""id"": 603, ""title"": ""The Matrix"", ""release_date"": ""1999-03-30"", ""original_language"": ""en"" }
+            ]
+        }");
+
+        var results = await _service.SearchMoviesAsync("inception");
+
+        Assert.That(results.Count, Is.EqualTo(2));
+        Assert.That(results[0].Id, Is.EqualTo(27205));
+        Assert.That(results[0].Title, Is.EqualTo("Inception"));
+        Assert.That(results[1].Id, Is.EqualTo(603));
+    }
+
+    [Test]
+    public async Task SearchMoviesAsync_ReturnsEmptyOnNoResults()
+    {
+        _mockHandler.SetResponse("search/movie", @"{ ""results"": [] }");
+
+        var results = await _service.SearchMoviesAsync("nonexistentmovie12345");
+
+        Assert.That(results, Is.Empty);
+    }
+
+    [Test]
+    public async Task GetDirectorAsync_ExtractsDirector()
+    {
+        _mockHandler.SetResponse("credits", @"{
+            ""crew"": [
+                { ""name"": ""Christopher Nolan"", ""job"": ""Director"" },
+                { ""name"": ""Hans Zimmer"", ""job"": ""Composer"" }
+            ]
+        }");
+
+        var director = await _service.GetDirectorAsync(27205);
+
+        Assert.That(director, Is.EqualTo("Christopher Nolan"));
+    }
+
+    [Test]
+    public async Task GetDirectorAsync_JoinsMultipleDirectors()
+    {
+        _mockHandler.SetResponse("credits", @"{
+            ""crew"": [
+                { ""name"": ""Lana Wachowski"", ""job"": ""Director"" },
+                { ""name"": ""Lilly Wachowski"", ""job"": ""Director"" }
+            ]
+        }");
+
+        var director = await _service.GetDirectorAsync(603);
+
+        Assert.That(director, Is.EqualTo("Lana Wachowski,Lilly Wachowski"));
+    }
+
+    [Test]
+    public async Task GetMoviePostersAsync_OrdersByVoteAverage()
+    {
+        _mockHandler.SetResponse("images", @"{
+            ""posters"": [
+                { ""file_path"": ""/poster1.jpg"", ""vote_average"": 5.0, ""vote_count"": 10, ""width"": 500, ""height"": 750 },
+                { ""file_path"": ""/poster2.jpg"", ""vote_average"": 8.5, ""vote_count"": 20, ""width"": 500, ""height"": 750 },
+                { ""file_path"": ""/poster3.jpg"", ""vote_average"": 7.0, ""vote_count"": 15, ""width"": 500, ""height"": 750 }
+            ]
+        }");
+
+        var posters = await _service.GetMoviePostersAsync(27205);
+
+        Assert.That(posters.Count, Is.EqualTo(3));
+        Assert.That(posters[0].FilePath, Is.EqualTo("/poster2.jpg"));
+        Assert.That(posters[1].FilePath, Is.EqualTo("/poster3.jpg"));
+        Assert.That(posters[2].FilePath, Is.EqualTo("/poster1.jpg"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add comprehensive unit test infrastructure using NUnit with NSubstitute for mocking
- Implement 35 unit tests covering all service classes (StatsService, CsvService, TmdbService, SiteGeneratorService, ConfigService)
- Update CI workflow to run both unit and integration tests
- Add solution file to organize CLI and test projects

## Test plan
- [x] Run `make unit-test` - all 35 tests pass
- [x] Run `make test` - both unit and integration tests pass
- [ ] Verify CI workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)