### PR TITLE
C# Lambda API with get-log endpoint

### DIFF
--- a/FilmStruck.sln
+++ b/FilmStruck.sln
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FilmStruck.Cli.Tests", "tests\FilmStruck.Cli.Tests\FilmStruck.Cli.Tests.csproj", "{0394D536-A88F-4506-A82F-78CDD6687C25}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FilmStruck.Api", "src\FilmStruck.Api\FilmStruck.Api.csproj", "{47E41FFD-60BA-4FE3-A0C2-BCDA4ED0F29D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,18 @@ Global
 		{0394D536-A88F-4506-A82F-78CDD6687C25}.Release|x64.Build.0 = Release|Any CPU
 		{0394D536-A88F-4506-A82F-78CDD6687C25}.Release|x86.ActiveCfg = Release|Any CPU
 		{0394D536-A88F-4506-A82F-78CDD6687C25}.Release|x86.Build.0 = Release|Any CPU
+		{47E41FFD-60BA-4FE3-A0C2-BCDA4ED0F29D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{47E41FFD-60BA-4FE3-A0C2-BCDA4ED0F29D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{47E41FFD-60BA-4FE3-A0C2-BCDA4ED0F29D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{47E41FFD-60BA-4FE3-A0C2-BCDA4ED0F29D}.Debug|x64.Build.0 = Debug|Any CPU
+		{47E41FFD-60BA-4FE3-A0C2-BCDA4ED0F29D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{47E41FFD-60BA-4FE3-A0C2-BCDA4ED0F29D}.Debug|x86.Build.0 = Debug|Any CPU
+		{47E41FFD-60BA-4FE3-A0C2-BCDA4ED0F29D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{47E41FFD-60BA-4FE3-A0C2-BCDA4ED0F29D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{47E41FFD-60BA-4FE3-A0C2-BCDA4ED0F29D}.Release|x64.ActiveCfg = Release|Any CPU
+		{47E41FFD-60BA-4FE3-A0C2-BCDA4ED0F29D}.Release|x64.Build.0 = Release|Any CPU
+		{47E41FFD-60BA-4FE3-A0C2-BCDA4ED0F29D}.Release|x86.ActiveCfg = Release|Any CPU
+		{47E41FFD-60BA-4FE3-A0C2-BCDA4ED0F29D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -52,5 +66,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{337ACE13-AD54-459E-9E4F-FEC4C60B1F13} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{0394D536-A88F-4506-A82F-78CDD6687C25} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{47E41FFD-60BA-4FE3-A0C2-BCDA4ED0F29D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/src/FilmStruck.Api/FilmStruck.Api.csproj
+++ b/src/FilmStruck.Api/FilmStruck.Api.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>FilmStruck.Api</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.7.2" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.405.4" />
+  </ItemGroup>
+
+</Project>

--- a/src/FilmStruck.Api/Models/FilmItem.cs
+++ b/src/FilmStruck.Api/Models/FilmItem.cs
@@ -1,0 +1,31 @@
+using Amazon.DynamoDBv2.DataModel;
+
+namespace FilmStruck.Api.Models;
+
+[DynamoDBTable("filmstruck")]
+public class FilmItem
+{
+    [DynamoDBHashKey("PartitionKey")]
+    public string PartitionKey { get; set; } = string.Empty;
+
+    [DynamoDBRangeKey("SortKey")]
+    public string SortKey { get; set; } = string.Empty;
+
+    [DynamoDBProperty("tmdbId")]
+    public string TmdbId { get; set; } = string.Empty;
+
+    [DynamoDBProperty("title")]
+    public string Title { get; set; } = string.Empty;
+
+    [DynamoDBProperty("director")]
+    public string Director { get; set; } = string.Empty;
+
+    [DynamoDBProperty("releaseYear")]
+    public string ReleaseYear { get; set; } = string.Empty;
+
+    [DynamoDBProperty("language")]
+    public string Language { get; set; } = string.Empty;
+
+    [DynamoDBProperty("posterPath")]
+    public string PosterPath { get; set; } = string.Empty;
+}

--- a/src/FilmStruck.Api/Models/LogItem.cs
+++ b/src/FilmStruck.Api/Models/LogItem.cs
@@ -1,0 +1,28 @@
+using Amazon.DynamoDBv2.DataModel;
+
+namespace FilmStruck.Api.Models;
+
+[DynamoDBTable("filmstruck")]
+public class LogItem
+{
+    [DynamoDBHashKey("PartitionKey")]
+    public string PartitionKey { get; set; } = string.Empty;
+
+    [DynamoDBRangeKey("SortKey")]
+    public string SortKey { get; set; } = string.Empty;
+
+    [DynamoDBProperty("date")]
+    public string Date { get; set; } = string.Empty;
+
+    [DynamoDBProperty("title")]
+    public string Title { get; set; } = string.Empty;
+
+    [DynamoDBProperty("location")]
+    public string Location { get; set; } = string.Empty;
+
+    [DynamoDBProperty("companions")]
+    public string Companions { get; set; } = string.Empty;
+
+    [DynamoDBProperty("tmdbId")]
+    public string TmdbId { get; set; } = string.Empty;
+}

--- a/src/FilmStruck.Api/Models/LogResponse.cs
+++ b/src/FilmStruck.Api/Models/LogResponse.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace FilmStruck.Api.Models;
+
+public class LogResponse
+{
+    [JsonPropertyName("username")]
+    public string Username { get; set; } = string.Empty;
+
+    [JsonPropertyName("count")]
+    public int Count { get; set; }
+
+    [JsonPropertyName("entries")]
+    public List<LogEntry> Entries { get; set; } = [];
+}
+
+public class LogEntry
+{
+    [JsonPropertyName("date")]
+    public string Date { get; set; } = string.Empty;
+
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = string.Empty;
+
+    [JsonPropertyName("location")]
+    public string Location { get; set; } = string.Empty;
+
+    [JsonPropertyName("companions")]
+    public string Companions { get; set; } = string.Empty;
+
+    [JsonPropertyName("tmdbId")]
+    public string TmdbId { get; set; } = string.Empty;
+
+    [JsonPropertyName("director")]
+    public string? Director { get; set; }
+
+    [JsonPropertyName("releaseYear")]
+    public string? ReleaseYear { get; set; }
+
+    [JsonPropertyName("language")]
+    public string? Language { get; set; }
+
+    [JsonPropertyName("posterPath")]
+    public string? PosterPath { get; set; }
+}

--- a/src/FilmStruck.Api/Program.cs
+++ b/src/FilmStruck.Api/Program.cs
@@ -1,0 +1,29 @@
+using Amazon.DynamoDBv2;
+using FilmStruck.Api.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton<IAmazonDynamoDB>(_ =>
+{
+    var endpointUrl = Environment.GetEnvironmentVariable("AWS_ENDPOINT_URL");
+    if (!string.IsNullOrEmpty(endpointUrl))
+    {
+        var config = new AmazonDynamoDBConfig { ServiceURL = endpointUrl };
+        return new AmazonDynamoDBClient(config);
+    }
+    return new AmazonDynamoDBClient();
+});
+
+builder.Services.AddSingleton<WatchLogService>();
+
+builder.Services.AddAWSLambdaHosting(LambdaEventSource.RestApi);
+
+var app = builder.Build();
+
+app.MapGet("/api/{username}", async (string username, WatchLogService service) =>
+{
+    var response = await service.GetWatchLog(username);
+    return Results.Ok(response);
+});
+
+app.Run();

--- a/src/FilmStruck.Api/Services/WatchLogService.cs
+++ b/src/FilmStruck.Api/Services/WatchLogService.cs
@@ -1,0 +1,115 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using FilmStruck.Api.Models;
+
+namespace FilmStruck.Api.Services;
+
+public class WatchLogService
+{
+    private readonly IAmazonDynamoDB _dynamoDb;
+    private readonly string _tableName;
+
+    public WatchLogService(IAmazonDynamoDB dynamoDb)
+    {
+        _dynamoDb = dynamoDb;
+        _tableName = Environment.GetEnvironmentVariable("TABLE_NAME") ?? "filmstruck-staging";
+    }
+
+    public async Task<LogResponse> GetWatchLog(string username)
+    {
+        var request = new QueryRequest
+        {
+            TableName = _tableName,
+            KeyConditionExpression = "PartitionKey = :pk",
+            ExpressionAttributeValues = new Dictionary<string, AttributeValue>
+            {
+                { ":pk", new AttributeValue { S = username } }
+            }
+        };
+
+        var result = await _dynamoDb.QueryAsync(request);
+
+        var logItems = new List<LogItem>();
+        var filmItems = new Dictionary<string, FilmItem>();
+
+        foreach (var item in result.Items)
+        {
+            var sortKey = item["SortKey"].S;
+
+            if (sortKey.StartsWith("Log#"))
+            {
+                logItems.Add(new LogItem
+                {
+                    PartitionKey = item["PartitionKey"].S,
+                    SortKey = sortKey,
+                    Date = GetStringValue(item, "date"),
+                    Title = GetStringValue(item, "title"),
+                    Location = GetStringValue(item, "location"),
+                    Companions = GetStringValue(item, "companions"),
+                    TmdbId = GetStringValue(item, "tmdbId"),
+                });
+            }
+            else if (sortKey.StartsWith("Film#"))
+            {
+                var tmdbId = GetStringValue(item, "tmdbId");
+                filmItems[tmdbId] = new FilmItem
+                {
+                    PartitionKey = item["PartitionKey"].S,
+                    SortKey = sortKey,
+                    TmdbId = tmdbId,
+                    Title = GetStringValue(item, "title"),
+                    Director = GetStringValue(item, "director"),
+                    ReleaseYear = GetStringValue(item, "releaseYear"),
+                    Language = GetStringValue(item, "language"),
+                    PosterPath = GetStringValue(item, "posterPath"),
+                };
+            }
+        }
+
+        var entries = logItems
+            .Select(log =>
+            {
+                var entry = new LogEntry
+                {
+                    Date = log.Date,
+                    Title = log.Title,
+                    Location = log.Location,
+                    Companions = log.Companions,
+                    TmdbId = log.TmdbId,
+                };
+
+                if (filmItems.TryGetValue(log.TmdbId, out var film))
+                {
+                    entry.Director = film.Director;
+                    entry.ReleaseYear = film.ReleaseYear;
+                    entry.Language = film.Language;
+                    entry.PosterPath = film.PosterPath;
+                }
+
+                return entry;
+            })
+            .OrderByDescending(e => ParseDate(e.Date))
+            .ToList();
+
+        return new LogResponse
+        {
+            Username = username,
+            Count = entries.Count,
+            Entries = entries,
+        };
+    }
+
+    private static string GetStringValue(Dictionary<string, AttributeValue> item, string key)
+    {
+        return item.TryGetValue(key, out var value) ? value.S ?? string.Empty : string.Empty;
+    }
+
+    private static DateTime ParseDate(string date)
+    {
+        if (DateTime.TryParseExact(date, "M/d/yyyy", null, System.Globalization.DateTimeStyles.None, out var parsed))
+            return parsed;
+        if (DateTime.TryParse(date, out var fallback))
+            return fallback;
+        return DateTime.MinValue;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `src/FilmStruck.Api/`, a .NET 9 minimal API deployed as an AWS Lambda
- `GET /api/{username}` queries DynamoDB for all Log and Film items, joins by tmdbId, returns enriched entries sorted newest-first
- DynamoDB models (`LogItem`, `FilmItem`) and API response DTOs (`LogResponse`, `LogEntry`)
- `WatchLogService` handles single-query fetch + in-memory join logic
- Supports local development via `AWS_ENDPOINT_URL` for DynamoDB Local
- Updates `FilmStruck.sln` to include the new project

**Stack 2 of 3** — base: #28 (CDK infrastructure), next: #30 (local dev environment)

## Test plan

- [x] `dotnet build src/FilmStruck.Api/FilmStruck.Api.csproj` succeeds
- [x] `dotnet build FilmStruck.sln` builds all projects cleanly
- [ ] Review DynamoDB query logic in `WatchLogService.cs`
- [ ] Review API response shape in `LogResponse.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)