### PR TITLE
Local dev environment with Docker, Makefile targets, and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: build test unit-test integration-test clean reinstall help
+.PHONY: build test unit-test integration-test clean reinstall help \
+       api-build api-run infra-install infra-synth infra-deploy-staging infra-deploy-prod local-up
 
 build:
 	dotnet build src/FilmStruck.Cli/FilmStruck.Cli.csproj
@@ -17,10 +18,42 @@ clean:
 reinstall:
 	./scripts/reinstall.sh
 
+api-build:
+	dotnet build src/FilmStruck.Api/FilmStruck.Api.csproj
+
+api-run:
+	AWS_ENDPOINT_URL=http://localhost:8000 TABLE_NAME=filmstruck-staging \
+		dotnet run --project src/FilmStruck.Api/FilmStruck.Api.csproj
+
+infra-install:
+	cd infra && npm install
+
+infra-synth:
+	cd infra && npx cdk synth -c env=staging
+
+infra-deploy-staging:
+	dotnet publish src/FilmStruck.Api/FilmStruck.Api.csproj -c Release -r linux-x64 --self-contained
+	cd infra && npx cdk deploy -c env=staging
+
+infra-deploy-prod:
+	dotnet publish src/FilmStruck.Api/FilmStruck.Api.csproj -c Release -r linux-x64 --self-contained
+	cd infra && npx cdk deploy -c env=prod
+
+local-up:
+	docker compose up -d
+	./scripts/local-setup.sh
+
 help:
-	@echo "make build            - Build the CLI"
-	@echo "make test             - Run all tests (unit + integration)"
-	@echo "make unit-test        - Run unit tests only"
-	@echo "make integration-test - Run integration tests only"
-	@echo "make clean            - Clean build artifacts"
-	@echo "make reinstall        - Reinstall CLI globally"
+	@echo "make build              - Build the CLI"
+	@echo "make test               - Run all tests (unit + integration)"
+	@echo "make unit-test          - Run unit tests only"
+	@echo "make integration-test   - Run integration tests only"
+	@echo "make clean              - Clean build artifacts"
+	@echo "make reinstall          - Reinstall CLI globally"
+	@echo "make api-build          - Build the API project"
+	@echo "make api-run            - Run API locally (needs DynamoDB Local)"
+	@echo "make infra-install      - Install CDK dependencies"
+	@echo "make infra-synth        - Synthesize CloudFormation template"
+	@echo "make infra-deploy-staging - Deploy to staging"
+	@echo "make infra-deploy-prod  - Deploy to production"
+	@echo "make local-up           - Start DynamoDB Local + seed data"

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,9 @@ infra-synth:
 	cd infra && npx cdk synth -c env=staging
 
 infra-deploy-staging:
-	dotnet publish src/FilmStruck.Api/FilmStruck.Api.csproj -c Release -r linux-x64 --self-contained
 	cd infra && npx cdk deploy -c env=staging
 
 infra-deploy-prod:
-	dotnet publish src/FilmStruck.Api/FilmStruck.Api.csproj -c Release -r linux-x64 --self-contained
 	cd infra && npx cdk deploy -c env=prod
 
 local-up:

--- a/README.md
+++ b/README.md
@@ -254,9 +254,42 @@ See a fully populated example at [s4s-filmstruck](https://github.com/shreshthkhi
 - Companion filtering in action
 - Custom favicon example
 
+## API
+
+FilmStruck also provides a public API for accessing watch log data, backed by AWS Lambda and DynamoDB.
+
+### `GET /api/{username}`
+
+Returns a user's enriched watch log (log entries joined with TMDB film metadata), sorted newest-first.
+
+**Production:** `https://filmstruck.net/api/{username}`
+**Staging:** `https://staging.filmstruck.net/api/{username}`
+
+Example response:
+
+```json
+{
+  "username": "alice",
+  "count": 2,
+  "entries": [
+    {
+      "date": "2/10/2025",
+      "title": "Pulp Fiction",
+      "location": "Home",
+      "companions": "Bob",
+      "tmdbId": "680",
+      "director": "Quentin Tarantino",
+      "releaseYear": "1994",
+      "language": "en",
+      "posterPath": "/d5iIlFn5s0ImszYzBPb8JPIfbXD.jpg"
+    }
+  ]
+}
+```
+
 ## Development
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for information on developing the CLI.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for information on developing the CLI and API.
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for technical specification.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  dynamodb-local:
+    image: amazon/dynamodb-local:latest
+    container_name: filmstruck-dynamodb
+    ports:
+      - "8000:8000"
+    command: "-jar DynamoDBLocal.jar -sharedDb -inMemory"
+    restart: unless-stopped

--- a/scripts/local-setup.sh
+++ b/scripts/local-setup.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENDPOINT="http://localhost:8000"
+TABLE_NAME="filmstruck-staging"
+REGION="us-east-1"
+
+echo "Creating DynamoDB table: $TABLE_NAME"
+aws dynamodb create-table \
+  --table-name "$TABLE_NAME" \
+  --attribute-definitions \
+    AttributeName=PartitionKey,AttributeType=S \
+    AttributeName=SortKey,AttributeType=S \
+  --key-schema \
+    AttributeName=PartitionKey,KeyType=HASH \
+    AttributeName=SortKey,KeyType=RANGE \
+  --billing-mode PAY_PER_REQUEST \
+  --endpoint-url "$ENDPOINT" \
+  --region "$REGION" \
+  2>/dev/null || echo "Table already exists, continuing..."
+
+echo "Seeding sample data..."
+
+USERNAME="testuser"
+
+# Seed Film items
+aws dynamodb put-item --table-name "$TABLE_NAME" --endpoint-url "$ENDPOINT" --region "$REGION" --item '{
+  "PartitionKey": {"S": "'"$USERNAME"'"},
+  "SortKey": {"S": "Film#278"},
+  "tmdbId": {"S": "278"},
+  "title": {"S": "The Shawshank Redemption"},
+  "director": {"S": "Frank Darabont"},
+  "releaseYear": {"S": "1994"},
+  "language": {"S": "en"},
+  "posterPath": {"S": "/9cjIGRiQoJmTnaE-HGYUhKZe4gf.jpg"}
+}'
+
+aws dynamodb put-item --table-name "$TABLE_NAME" --endpoint-url "$ENDPOINT" --region "$REGION" --item '{
+  "PartitionKey": {"S": "'"$USERNAME"'"},
+  "SortKey": {"S": "Film#238"},
+  "tmdbId": {"S": "238"},
+  "title": {"S": "The Godfather"},
+  "director": {"S": "Francis Ford Coppola"},
+  "releaseYear": {"S": "1972"},
+  "language": {"S": "en"},
+  "posterPath": {"S": "/3bhkrj58Vtu7enYsRolD1fZdja1.jpg"}
+}'
+
+aws dynamodb put-item --table-name "$TABLE_NAME" --endpoint-url "$ENDPOINT" --region "$REGION" --item '{
+  "PartitionKey": {"S": "'"$USERNAME"'"},
+  "SortKey": {"S": "Film#680"},
+  "tmdbId": {"S": "680"},
+  "title": {"S": "Pulp Fiction"},
+  "director": {"S": "Quentin Tarantino"},
+  "releaseYear": {"S": "1994"},
+  "language": {"S": "en"},
+  "posterPath": {"S": "/d5iIlFn5s0ImszYzBPb8JPIfbXD.jpg"}
+}'
+
+# Seed Log items
+aws dynamodb put-item --table-name "$TABLE_NAME" --endpoint-url "$ENDPOINT" --region "$REGION" --item '{
+  "PartitionKey": {"S": "'"$USERNAME"'"},
+  "SortKey": {"S": "Log#2025-01-15#278"},
+  "date": {"S": "1/15/2025"},
+  "title": {"S": "The Shawshank Redemption"},
+  "location": {"S": "Home"},
+  "companions": {"S": ""},
+  "tmdbId": {"S": "278"}
+}'
+
+aws dynamodb put-item --table-name "$TABLE_NAME" --endpoint-url "$ENDPOINT" --region "$REGION" --item '{
+  "PartitionKey": {"S": "'"$USERNAME"'"},
+  "SortKey": {"S": "Log#2025-02-01#238"},
+  "date": {"S": "2/1/2025"},
+  "title": {"S": "The Godfather"},
+  "location": {"S": "Theater"},
+  "companions": {"S": "Alice"},
+  "tmdbId": {"S": "238"}
+}'
+
+aws dynamodb put-item --table-name "$TABLE_NAME" --endpoint-url "$ENDPOINT" --region "$REGION" --item '{
+  "PartitionKey": {"S": "'"$USERNAME"'"},
+  "SortKey": {"S": "Log#2025-02-10#680"},
+  "date": {"S": "2/10/2025"},
+  "title": {"S": "Pulp Fiction"},
+  "location": {"S": "Home"},
+  "companions": {"S": "Bob, Carol"},
+  "tmdbId": {"S": "680"}
+}'
+
+echo "Done! Seeded 3 films and 3 log entries for user: $USERNAME"
+echo "Test with: curl http://localhost:5000/api/$USERNAME"


### PR DESCRIPTION
## Summary

- Adds `docker-compose.yml` with DynamoDB Local on port 8000
- Adds `scripts/local-setup.sh` to create DDB table and seed 3 sample films/log entries
- Adds Makefile targets: `api-build`, `api-run`, `infra-install`, `infra-synth`, `infra-deploy-staging`, `infra-deploy-prod`, `local-up`
- Updates README with API section (endpoint, example response)
- Updates CONTRIBUTING with prerequisites, project structure, API key files, local API dev workflow
- Updates ARCHITECTURE with API architecture, DynamoDB table design, CDK stack resources, deployment instructions
- Updates CLAUDE.md with API development and infrastructure commands

**Stack 3 of 3** — base: #29 (C# Lambda API)

## Test plan

- [ ] `docker compose up -d` starts DynamoDB Local
- [ ] `./scripts/local-setup.sh` creates table and seeds data
- [ ] `make api-run` starts local API server
- [ ] `curl http://localhost:5000/api/testuser` returns enriched log JSON
- [ ] Review documentation updates in README, CONTRIBUTING, ARCHITECTURE

🤖 Generated with [Claude Code](https://claude.com/claude-code)